### PR TITLE
chore(goreleaser): remove windows and arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,12 +8,10 @@ builds:
   env:
   - CGO_ENABLED=0
   goos:
-  - windows
   - darwin
   - linux
   goarch:
   - amd64
-  - arm
   - arm64
 release:
   prerelease: true


### PR DESCRIPTION
Follow up #25

https://github.com/aquaproj/aqua-proxy/runs/6373769669?check_suite_focus=true

```
   ⨯ release failed after 42.63s error=failed to build for windows_amd64_v1: exit status 2: # github.com/aquaproj/aqua-proxy/pkg/cli
Error: pkg/cli/proxy.go:30:17: undefined: unix.Exec
```

Build for Windows failed.
aqua doesn't support Windows, so let's remove Windows from goreleaser's build target.