### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -5,9 +5,11 @@ permissions: {}
 jobs:
   autofix:
     runs-on: ubuntu-24.04
-    permissions: {}
+    permissions:
+      id-token: write
     timeout-minutes: 15
     steps:
       - uses: suzuki-shunsuke/go-autofix-action@9a8682f2dc2a935fe2a2ac96deb03de2dfcb872e # v0.1.13
         with:
           aqua_version: v2.59.1
+          takumi_guard_bot_id: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   release:
     uses: suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml@884a4badb955df4a4ddddd802e433096371f3157 # v8.1.0
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     with:
       go-version-file: go.mod
       aqua_version: v2.59.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,12 @@ jobs:
     steps:
       - run: exit 1
   test:
-    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@e442a17816baa8a940edc1544cc6e739d870e165 # v5.0.2
+    uses: suzuki-shunsuke/go-test-full-workflow/.github/workflows/test.yaml@98ab396ba72f7b47f7e22aca7346b6e1d7ae4deb # v6.0.0
     with:
       aqua_version: v2.59.1
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}
     permissions:
       pull-requests: write
       contents: read
+      id-token: write


### PR DESCRIPTION
## Overview

Introduce [Takumi Guard](https://github.com/suzuki-shunsuke/ghalint) (Go variant) into the CI workflows.

## Changes

### `release.yaml`
- Pass `secrets.TAKUMI_GUARD_BOT_ID` (the reusable workflow is already at v8.1.0).

### `test.yaml`
- Bump `go-test-full-workflow` v5.0.2 → v6.0.0, pass the secret, add `id-token: write`.

### `autofix.yaml`
- Add the `takumi_guard_bot_id` input and `id-token: write` permission (go-autofix-action already at v0.1.13).

## Note

- `go-test-full-workflow` crosses a **major** version (v5 → v6); please review CI for breaking changes.
- The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)